### PR TITLE
Automate API documentation generation and deployment

### DIFF
--- a/.github/workflows/docs-versioned.yml
+++ b/.github/workflows/docs-versioned.yml
@@ -1,0 +1,27 @@
+name: API documentation generation on release
+on:
+  push:
+    tags:
+    - 'v[0-9]+.[0-9]+.[0-9]+'
+
+jobs:
+  docs-versioned:
+    runs-on: ubuntu-latest
+    steps:
+    - name: Checkout
+      uses: actions/checkout@v3
+    - name: Setup JDK
+      uses: actions/setup-java@v3
+      with: 
+        distribution: temurin
+        java-version: 17
+    - name: Generate documentation
+      run: sbt doc
+    - name: Deploy
+      uses: peaceiris/actions-gh-pages@v3
+      with:
+        deploy_key: ${{ secrets.ACTIONS_DEPLOY_KEY }}
+        external_repository: portals-project/portals-api
+        publish_dir: './core/target/api'
+        destination_dir: ${{ github.ref_name }}
+        keep_files: true

--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -1,0 +1,38 @@
+name: Generate and deploy API documentation
+on:
+  push:
+    branches:
+    - main
+
+permissions:
+  contents: read
+  pages: write
+  id-token: write
+concurrency:
+  group: "pages"
+  cancel-in-progress: true
+jobs:
+  docs:
+    environment:
+      name: github-pages
+      url: ${{ steps.deployment.outputs.page_url }}
+    runs-on: ubuntu-latest
+    steps:
+    - name: Checkout
+      uses: actions/checkout@v3
+    - name: Setup Pages
+      uses: actions/configure-pages@v3
+    - name: Setup JDK
+      uses: actions/setup-java@v3
+      with: 
+        distribution: temurin
+        java-version: 17
+    - name: Generate documentation
+      run: sbt doc
+    - name: Upload artifact
+      uses: actions/upload-pages-artifact@v1
+      with:
+        path: './core/target/api'
+    - name: Deploy to GitHub Pages
+      id: deployment
+      uses: actions/deploy-pages@v1

--- a/build.sbt
+++ b/build.sbt
@@ -20,6 +20,7 @@ lazy val portals = project
   .in(file("core"))
   .settings(
     name := "portals",
+    Compile / doc / target := target.value / "api",
     libraryDependencies += "com.novocode" % "junit-interface" % junitInterfaceVersion % "test",
     libraryDependencies += "com.typesafe.akka" %% "akka-actor-typed" % akkaVersion,
     libraryDependencies += "ch.qos.logback" % "logback-classic" % logbackversion,


### PR DESCRIPTION
This commit adds two GitHub Actions workflows: docs and docs-versioned.

Workflow "docs" generates API documentation on each push to main and deploy it to GitHub Pages.  The repository needs to have GitHub Pages enabled and GitHub Actions setup as its input.

Workflow "docs-versioned" also generates the documentation, but on creation of tags of v[0-9]+.[0-9]+.[0-9]+ format, and then copies the result to portals-project/portals-api repository in a directory named the same way as tag.