### PR TITLE
Dynamic workflow submission

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -4,6 +4,7 @@ lazy val logbackversion = "1.2.11"
 lazy val akkaVersion = "2.6.20"
 lazy val pprintversion = "0.7.0"
 lazy val nexmarkVersion = "2.41.0"
+lazy val caskVersion = "0.8.3"
 
 ThisBuild / organization := "org.portals-project"
 ThisBuild / organizationName := "Portals-Project"
@@ -25,6 +26,7 @@ lazy val portals = project
     libraryDependencies += "com.typesafe.akka" %% "akka-actor-typed" % akkaVersion,
     libraryDependencies += "ch.qos.logback" % "logback-classic" % logbackversion,
     libraryDependencies += "com.lihaoyi" %% "pprint" % pprintversion,
+    libraryDependencies += "com.lihaoyi" %% "cask" % caskVersion,
   )
 
 lazy val benchmark = project

--- a/core/src/main/scala/portals/runtime/interpreter/InterpreterRuntime.scala
+++ b/core/src/main/scala/portals/runtime/interpreter/InterpreterRuntime.scala
@@ -15,7 +15,7 @@ import portals.runtime.WrappedEvents.*
 private[portals] class InterpreterRuntimeContext():
   private var _applications: Map[String, Application] = Map.empty
   private var _streams: Map[String, InterpreterStream] = Map.empty
-  private var _portals: Map[String, InterpreterPortal] = Map.empty
+  var _portals: Map[String, InterpreterPortal] = Map.empty
   private var _workflows: Map[String, InterpreterWorkflow] = Map.empty
   private var _sequencers: Map[String, InterpreterSequencer] = Map.empty
   private var _splitters: Map[String, InterpreterSplitter] = Map.empty
@@ -120,7 +120,7 @@ private[portals] class InterpreterStreamTracker:
   def getProgress(stream: String): Option[(Long, Long)] = _progress.get(stream)
 
 private[portals] class InterpreterRuntime(val seed: Option[Int] = None) extends PortalsRuntime:
-  private val rctx = new InterpreterRuntimeContext()
+  val rctx = new InterpreterRuntimeContext()
   private val progressTracker = InterpreterProgressTracker()
   private val streamTracker = InterpreterStreamTracker()
   private val graphTracker = InterpreterGraphTracker()

--- a/core/src/main/scala/portals/runtime/manager/JobManager.scala
+++ b/core/src/main/scala/portals/runtime/manager/JobManager.scala
@@ -1,0 +1,86 @@
+package portals.runtime.manager
+
+import java.io.File
+import java.net.URLClassLoader
+
+import portals.application.Application
+import portals.application.AtomicPortalRef
+import portals.runtime.manager.SubmittableApplication
+import portals.system.InterpreterSystem
+import portals.system.Systems
+import portals.util.Logger
+
+import cask.Request
+
+object JobManager {
+  val system: InterpreterSystem = Systems.interpreter()
+
+  def stepUntilComplete: Unit = {
+    system.stepUntilComplete()
+  }
+
+  def submitApplication(submittableApplication: SubmittableApplication): Unit = {
+    val app = submittableApplication.application
+    system.launch(app)
+    if (system.runtime.rctx.applications.size > 1) {
+      submittableApplication.portalStubs.foreach(portalSub => {
+        rewireStubPortal(portalSub.portal, portalSub.targetApplication)
+        // TODO: stub portals are also registered, but are not useful anymore, need to be cleared from app ctx
+      })
+    }
+    println("submitted " + app.path)
+  }
+
+  /** Points path for {@link PortalStub} to the actual application
+    */
+  def rewireStubPortal(portal: AtomicPortalRef[_, _], dstApplication: String): Unit = {
+    val oldPath = portal.path
+    val oldPathSplit = oldPath.split("/")
+    oldPathSplit(1) = dstApplication
+    val actualPath = oldPathSplit.mkString("/")
+
+    val pathField = portal.getClass.getDeclaredField("path")
+    pathField.setAccessible(true)
+    pathField.set(portal, actualPath)
+    pathField.setAccessible(false)
+
+    system.runtime.rctx._portals = system.runtime.rctx._portals - oldPath
+
+    println(s"rewired stub portal $oldPath to $actualPath")
+  }
+}
+
+object Server extends cask.MainRoutes {
+
+  // NOTE: classes with same fully-qualified name loaded by different classLoader instance are not the same type
+  // Warning: this chain may go to long if we submit too many applications
+  var currentClassLoader = Server.getClass.getClassLoader
+
+  @cask.get("/step")
+  def step() = {
+    JobManager.stepUntilComplete
+    "ok"
+  }
+
+  /** submit "/path/to/clsFile/root com.package.yourApplicationClass" */
+  @cask.post("/submitUrl")
+  def submitUrl(request: cask.Request) = {
+    val urlCls = request.text().split(" ");
+    println("body: " + request.text())
+    val url = urlCls(0)
+    val clsName = urlCls(1)
+
+    val f = new File(url)
+    // https://stackoverflow.com/a/3941480/8454039  Array equals []
+    currentClassLoader = new URLClassLoader(Array(f.toURI.toURL), currentClassLoader)
+    val cls = Class.forName(clsName, true, currentClassLoader)
+    val submittableApplication = cls.getConstructor().newInstance().asInstanceOf[SubmittableApplication]
+
+    println("loaded " + cls.getName)
+
+    JobManager.submitApplication(submittableApplication)
+    "ok"
+  }
+
+  initialize()
+}

--- a/core/src/main/scala/portals/runtime/manager/SubmittableApplication.scala
+++ b/core/src/main/scala/portals/runtime/manager/SubmittableApplication.scala
@@ -1,0 +1,22 @@
+package portals.runtime.manager
+
+import scala.collection.mutable.ListBuffer
+
+import portals.application.Application
+import portals.application.AtomicPortalRef
+
+case class PortalStub(portal: AtomicPortalRef[_, _], targetApplication: String)
+
+/** Application format that is allowed to submit incrementally */
+abstract class SubmittableApplication {
+
+  /** Remote portals that receives requests from this applications should be
+    * placed in {@link portalStubs}
+    */
+  val portalStubs = ListBuffer[PortalStub]()
+
+  def application: Application
+
+  def registerPortalStub(portal: AtomicPortalRef[_, _], targetApplication: String) =
+    portalStubs += PortalStub(portal, targetApplication)
+}

--- a/core/src/main/scala/portals/system/InterpreterSystem.scala
+++ b/core/src/main/scala/portals/system/InterpreterSystem.scala
@@ -10,7 +10,7 @@ import portals.system.PortalsSystem
   * stepping until it has completed.
   */
 class InterpreterSystem(seed: Option[Int] = None) extends PortalsSystem:
-  private val runtime: InterpreterRuntime = InterpreterRuntime(seed)
+  val runtime: InterpreterRuntime = InterpreterRuntime(seed)
 
   /** Launch a Portals application. */
   def launch(application: Application): Unit = runtime.launch(application)

--- a/examples/src/main/scala/portals/examples/experimental/DynamicWorkflowSubmission.scala
+++ b/examples/src/main/scala/portals/examples/experimental/DynamicWorkflowSubmission.scala
@@ -1,0 +1,131 @@
+package portals.examples.experimental
+
+import scala.annotation.experimental
+
+import portals.api.builder.ApplicationBuilder
+import portals.api.builder.TaskBuilder
+import portals.api.dsl.DSL.Generators
+import portals.api.dsl.DSL.Portal
+import portals.api.dsl.DSL.PortalsApp
+import portals.api.dsl.DSL.Workflows
+import portals.application.task.AskerTask
+import portals.application.task.PerTaskState
+import portals.application.task.ReplierTask
+import portals.application.task.StatefulTaskContext
+import portals.application.Application
+import portals.application.AtomicPortalRef
+import portals.runtime.manager.PortalStub
+import portals.runtime.manager.SubmittableApplication
+import portals.util.Future
+
+class DynamicWorkflowSubmission {}
+
+// =======================================
+// =========== Util Classes ==============
+// =======================================
+
+case class Query(sql: String, requestId: String = "", key: String = "")
+
+case class QueryResult(message: String, requestId: String = "", rows: List[Tuple] = List())
+
+def keyFrom(query: Query): Long = query.key.hashCode()
+
+@experimental
+object WorkflowSubmissionUtils:
+
+  import portals.api.dsl.DSL.*
+  import portals.api.dsl.ExperimentalDSL.*
+
+  def dummyAskingWorkflow(portal: AtomicPortalRef[_, _])(using ab: ApplicationBuilder) =
+    Workflows[Nothing, Nothing]("dummyAskingWorkflow")
+      .source(Generators.empty.stream)
+      .asker[Nothing](portal) { * => () }
+      .sink()
+      .freeze()
+
+  def dummyReplierWorkflow(portal: AtomicPortalRef[_, _])(using ab: ApplicationBuilder) =
+    Workflows[Nothing, Nothing]("dummyReplierWorkflow")
+      .source(Generators.empty.stream)
+      .replier[Nothing](portal) { * => () } { * => () }
+      .sink()
+      .freeze()
+
+// =======================================
+// =========== Application ===============
+// =======================================
+
+@experimental
+class BankAccountApplication extends SubmittableApplication {
+
+  import portals.api.dsl.DSL.*
+  import portals.api.dsl.ExperimentalDSL.*
+
+  //  override def application: Application = Queryable.genBankAccountAppWithNoQuerier
+  override def application: Application =
+    PortalsApp("bankApp") {
+
+      val bankAccountPortal = Portal[Query, QueryResult]("bankAccountPortal", keyFrom)
+
+      val generator = Generators.fromList(List[String]("balabala"))
+      Workflows[String, Nothing]("bankAccount-")
+        .source(generator.stream)
+        .task[Nothing](accountTask(bankAccountPortal))
+        .withName("bankAccountTask")
+        .withName("bankAccountReplier")
+        .sink()
+        .freeze()
+
+      // NOTE: not used, for passing the wellformedness check only
+      WorkflowSubmissionUtils.dummyAskingWorkflow(bankAccountPortal)
+    }
+
+  val replierState: StatefulTaskContext ?=> PerTaskState[Int] = PerTaskState("bankAccountState", 1)
+
+  def accountTask(portals: AtomicPortalRef[Query, QueryResult]) =
+    TaskBuilder.replier[String, Nothing, Query, QueryResult](portals)(e => ctx.log.info(s"received regular event $e")) {
+      query =>
+        ctx.log.info(s"received query: ${query.sql} [${query.requestId}]")
+        replierState.set(replierState.get() + 1)
+        reply(QueryResult(replierState.get().toString, query.requestId))
+    }
+}
+
+@experimental
+class QueryApplication extends SubmittableApplication {
+
+  import portals.api.dsl.DSL.*
+  import portals.api.dsl.ExperimentalDSL.*
+
+  override def application: Application =
+    import portals.api.dsl.ExperimentalDSL.*
+
+    PortalsApp("queryApp") {
+      ////////////////////////////////////////////////////////////////////////////
+      // Query Origin
+      ////////////////////////////////////////////////////////////////////////////
+      val bankAccountPortal = Portal[Query, QueryResult]("bankAccountPortal", keyFrom)
+      registerPortalStub(bankAccountPortal, "bankApp")
+
+      val queries = Generators.fromList[Query](List(Query("xxx"), Query("yyy")))
+
+      Workflows[Query, Nothing]("queryWorkflow")
+        .source(queries.stream)
+        .task(queryTask(bankAccountPortal))
+        .withName("baQuerier")
+        .withName("querier")
+        .sink()
+        .freeze()
+
+      // NOTE: not used, for passing the wellformedness check only
+      WorkflowSubmissionUtils.dummyReplierWorkflow(bankAccountPortal)
+    }
+
+  def queryTask(portals: AtomicPortalRef[Query, QueryResult]) =
+    TaskBuilder.asker[Query, Nothing, Query, QueryResult](portals) { query =>
+      ctx.log.info(s"rcvd query: ${query.sql} [${query.requestId}]")
+      val future: Future[QueryResult] = ask(portals)(query)
+      future.await {
+        ctx.log.info(s"got reply: ${future.value.get.message} [${future.value.get.requestId}]")
+      }
+    }
+}


### PR DESCRIPTION
Scenario: 2 applications, one includes a bankAccount workflow, the other includes a query workflow, we want these two separately submitted workflows to be able to send askings/replies to each other.

How to run the demo:
1. Compile the project
2. Start the server at JobManager.scala
3. Run these commands (need to change the path)

```
curl -X POST localhost:8080/submitUrl -d '/home/yang/Workspace/github/portals/examples/target/scala-3.3.0/classes portals.examples.experimental.BankAccountApplication'
curl localhost:8080/step
curl -X POST localhost:8080/submitUrl -d '/home/yang/Workspace/github/portals/examples/target/scala-3.3.0/classes portals.examples.experimental.QueryApplication'
curl localhost:8080/step
```